### PR TITLE
Updated python script with documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,11 @@ optional arguments:
 The following actions can be performed:
 * register: registers and uploads a UI plugin
   * requires a plugin directory to be specified, and the plugin to already be built and available in the `dist/` folder
+    * _if not specified, the directory where the script was executed is used_
 * unregister: removes a plugin
   * requires an id to be specified, corresponding to the id of an existing registered plugin
+    * _if not specified, the id is then discovered prior to plugin removal_
+  * requires a plugin directory to be specified, and the plugin to already be built and available in the `dist/` folder
+    * _if not specified, the directory where the script was executed is used_
 * list: provides a summary of currently registered plugins
   * requires no additional parameters


### PR DESCRIPTION
Functionality added so it behaves more similar to the [legacy python script](https://github.com/vmware/vcd-ext-sdk/blob/master/ui/vcd-plugin-seed/ui_ext_api.py).

- Enhancements to script:
  - added function allowing plugin ID to be discovered
  - able to now 'register' plugin even if already registered
  - able to now 'unregister' plugin even if ID is not specified
- Updated documentation accordingly
- Testing done:
  - `pylint` to make sure standards were observed
  - tested script with all parameter configurations
    - `register`
      - no parameters
      - specified different plugin folder
    - `unregister`
      - no parameters
      - specified plugin ID
      - specified no plugin id with different plugin folder
      - specified plugin ID with different plugin folder

Signed-off-by: Chris Arceneaux <carcenea@gmail.com>