### PR TITLE
[VDU-6434] [Scale]Extension publish event makes the user wait for mor…

### DIFF
--- a/src/main/common/services/organization.service.ts
+++ b/src/main/common/services/organization.service.ts
@@ -1,7 +1,7 @@
 import {Injectable} from "@angular/core";
 import {Observable} from "rxjs";
 import {ApiPluginTenant, PluginTenantSpec, toPluginTenantSpecs} from "../../plugins/plugin.model";
-import {QueryResultOrgRecordType, QueryResultRecordsType} from "@vcd/bindings/vcloud/api/rest/schema_v1_5";
+import {QueryResultOrgRecordType, QueryResultRecordsType, ReferenceType} from "@vcd/bindings/vcloud/api/rest/schema_v1_5";
 import {Query} from "@vcd/sdk/query";
 import {VcdApiClient} from "@vcd/sdk/client";
 import {expand, map, reduce, take} from "rxjs/operators";
@@ -14,20 +14,22 @@ import {expand, map, reduce, take} from "rxjs/operators";
 export class OrganizationService {
     constructor(private client: VcdApiClient) {}
 
-    getAllTenants(): Observable<QueryResultOrgRecordType[]> {
+    getAllTenants(): Observable<ReferenceType[]> {
         return this.client
             .query<QueryResultRecordsType>(
                 Query.Builder
-                    .ofType("organization")
-                    .format("idrecords")
-                    .sort({field: "name", reverse: false})
+                .ofType("organization")
+                .format("references")
+                .sort({field: "name", reverse: false})
+                .links(false)
+                .pageSize(128)
             )
             .pipe(
                 expand((pageResponse: QueryResultRecordsType) => (!this.client.hasNextPage(pageResponse)
                     ? Observable.empty()
                     : this.client.nextPage(pageResponse))),
-                map((pageResponse: QueryResultRecordsType) => pageResponse.record as QueryResultOrgRecordType[]),
-                reduce((accumulator: QueryResultOrgRecordType[], next: QueryResultOrgRecordType[]) => [...accumulator, ...next]),
+                map((pageResponse: QueryResultRecordsType) => pageResponse["reference"] as ReferenceType[]),
+                reduce((accumulator: ReferenceType[], next: ReferenceType[]) => [...accumulator, ...next]),
                 take(1)
         );
     }


### PR DESCRIPTION
…e than 5 minutes to load 3000+ orgs information

Reduce the number of API calls and also the size,
to prevent long loading time of the publish modal.

For example there are 3000+ organization loading time
will be 5+ min.

Testing Done:
- Verify publish tenant modal still works with smaller
response objects.

Signed-off-by: Nikola Vladimirov Iliev <nvladimirovi@vmware.com>