### PR TITLE
Added Tenant PublishAll API Call

### DIFF
--- a/manage_plugin.py
+++ b/manage_plugin.py
@@ -52,6 +52,12 @@ class PluginManager:
         time.sleep(3)
         response = self._session.get('{}/cloudapi/extensions/ui/{}'.format(self.vcdUrlBase, pluginId), data=registerRequest)
         print('Plugin status: {}'.format(response.json()['plugin_status']))
+
+        if "tenant" in manifest['scope']:
+            print('Publishing plugin to all tenants...')
+            response = self._session.post('{}/cloudapi/extensions/ui/{}/tenants/publishAll'.format(self.vcdUrlBase, pluginId))
+            print('Plugin published to {} Tenants'.format(len(response.json())))
+
         return
 
     def list(self):


### PR DESCRIPTION
Resolves issue #14.

- vCD 10 changes default API behavior when uploading plugins
  - **POST**:`/cloudapi/extensions/ui/{id}/plugin`
  - By default, newly uploaded plugins will not be published to tenants
- Newly added code will be publish the plugin to all tenants if the `tenant` scope is specified in the `manifest.json`
  - API call used to publish plugin - `/cloudapi/extensions/ui/{id}/tenants/publishAll` - has been around since vCD version 9.1.0.2 so compatibility with previous versions of vCD is maintained.

Signed-off-by: Chris Arceneaux <carcenea@gmail.com>