### PR TITLE
[VACE-2647] Fix Customize Portal after NG Upgrade

### DIFF
--- a/src/main/plugins/publish-modal.component.ts
+++ b/src/main/plugins/publish-modal.component.ts
@@ -27,6 +27,10 @@ export class PublishModalComponent {
     }
 
     get loading() {
+        if (!this.publishForm) {
+            return true;
+        }
+
         return this.publishForm.loading;
     }
 


### PR DESCRIPTION
After the ng upgrade, something in the angular detect changes mechanism changed
and now the assumtion which we've in the code that the publish form exists is not correct.

Testing Done:
- Verify the plugin can be compiled
- Verfiy the plugin works