### PR TITLE
[VACE-2595] Fix Customize Portal UI Plugin

### DIFF
--- a/src/main/plugins/plugin.model.ts
+++ b/src/main/plugins/plugin.model.ts
@@ -1,5 +1,5 @@
 import {EntityReference2, UiPluginMetadataResponse} from "@vcd/bindings/vcloud/rest/openapi/model";
-import {plugin} from "postcss";
+import { LinkType } from "@vcd/bindings/vcloud/api/rest/schema_v1_5";
 
 export type ApiPlugin = UiPluginMetadataResponse;
 
@@ -18,6 +18,15 @@ export interface PluginSpec {
     tenantScoped: boolean;
     providerScoped: boolean;
     resourcePath?: string;
+}
+
+export interface EntityReferences {
+    resultTotal: number;
+    pageCount: number;
+    page: number;
+    pageSize: number;
+    values: PluginTenantSpec[];
+    link?: LinkType[];
 }
 
 export interface PluginTenantSpec {

--- a/src/main/plugins/publish-modal.component.ts
+++ b/src/main/plugins/publish-modal.component.ts
@@ -27,6 +27,10 @@ export class PublishModalComponent {
     }
 
     get loading() {
+        if (!this.publishForm) {
+            return true;
+        }
+
         return this.publishForm.loading;
     }
 


### PR DESCRIPTION
Fix the get tenants methods, after implementing pagination
support for those endpoints.

Testing done:
- Verify the plugin is able  to get all tenants in various ways.
- Verfy the links, from the  response headers, are in the response body
as well.

Signed-off-by: Nikola Vladimirov Iliev <nvladimirovi@vmware.com>