### PR TITLE
[VACE-2704] Customize Portal change to publish all

### DIFF
--- a/src/main/plugins/plugin-operations.model.ts
+++ b/src/main/plugins/plugin-operations.model.ts
@@ -10,6 +10,7 @@ export interface PublishPluginsOperationSpec {
     providerScoped: boolean;
     tenantScoped: boolean;
     tenants: PluginTenantSpec[];
+    publishToAll: boolean;
 }
 
 export interface PluginUploadOperationSpec {

--- a/src/main/plugins/plugin-operations.service.ts
+++ b/src/main/plugins/plugin-operations.service.ts
@@ -106,7 +106,13 @@ export class PluginOperationsService {
 
     private republishToTenants(state: PublishPluginsOperationSpec) {
         const actions = state.plugins
-            .map((plugin) => this.pluginService.publishToTenants(plugin, state.tenants));
+            .map((plugin) => {
+                if (state.publishToAll) {
+                    return this.pluginService.publishToAllTenants(plugin);
+                }
+
+                return this.pluginService.publishToTenants(plugin, state.tenants)
+            });
         return Observable.forkJoin(actions)
             .pipe(
                 map(() => state)

--- a/src/main/plugins/plugin.model.ts
+++ b/src/main/plugins/plugin.model.ts
@@ -1,5 +1,5 @@
 import {EntityReference2, UiPluginMetadataResponse} from "@vcd/bindings/vcloud/rest/openapi/model";
-import {plugin} from "postcss";
+import { LinkType } from "@vcd/bindings/vcloud/api/rest/schema_v1_5";
 
 export type ApiPlugin = UiPluginMetadataResponse;
 
@@ -18,6 +18,15 @@ export interface PluginSpec {
     tenantScoped: boolean;
     providerScoped: boolean;
     resourcePath?: string;
+}
+
+export interface EntityReferences {
+    resultTotal: number;
+    pageCount: number;
+    page: number;
+    pageSize: number;
+    values: PluginTenantSpec[];
+    link?: LinkType[];
 }
 
 export interface PluginTenantSpec {

--- a/src/main/plugins/publish-form.component.ts
+++ b/src/main/plugins/publish-form.component.ts
@@ -81,7 +81,7 @@ export class PublishFormComponent {
                 tenants.push(this.tenantsById.get(selection.tenantId));
             }
         });
-        return {plugins, tenantScoped, providerScoped, tenants};
+        return {plugins, tenantScoped, providerScoped, tenants, publishToAll: this.allTenantsChecked};
     }
 
     get loading() {

--- a/src/main/plugins/publish-modal.component.ts
+++ b/src/main/plugins/publish-modal.component.ts
@@ -27,6 +27,10 @@ export class PublishModalComponent {
     }
 
     get loading() {
+        if (!this.publishForm) {
+            return true;
+        }
+
         return this.publishForm.loading;
     }
 


### PR DESCRIPTION
Currently when you want to publish a plugin(s) to all tenants,
this is done by calling the endpoint which will publish it only to
specific list of tenants, we have to change it to publishAll endpoint.

Testing Done:
- Verify the plugins are  published to all when needed,
and to specific when this is selected.

Signed-off-by: Nikola Vladimirov Iliev <nvladimirovi@vmware.com>