### PR TITLE
[VACE-2722] Fix Customize Portal Plugin validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@ngrx/effects": "2.0.3",
     "@ngrx/store": "2.2.2",
     "@vcd/bindings": "9.1.1",
-    "@vcd/sdk": "0.9.0",
+    "@vcd/sdk": "0.12.0",
     "@webcomponents/custom-elements": "1.0.0",
     "codelyzer": "4.5.0",
     "clarity-angular": "0.10.17",
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@types/jasmine": "2.5.47",
-    "@types/jszip": "^3.1.4",
+    "@types/jszip": "3.1.5",
     "@types/node": "7.0.12",
     "angular2-template-loader": "0.6.2",
     "autoprefixer": "9.3.1",

--- a/src/main/plugins/plugin-bundle.service.ts
+++ b/src/main/plugins/plugin-bundle.service.ts
@@ -71,16 +71,4 @@ export class PluginBundleService {
            );
     }
 
-    validatePluginBundle(pluginBundle: PluginBundleSpec): boolean {
-        for (const filename of pluginBundle.filenames) {
-            const valid = /^(?!..\/)(((manifest|i18n|).(json)$)|((bundle).(js)$)|([0-9]|[a-z]+\/)([0-9]|[a-z]+).*[^exe]$)/gm
-                .test(filename);
-            if (!valid) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
 }

--- a/src/main/plugins/upload-wizard.component.html
+++ b/src/main/plugins/upload-wizard.component.html
@@ -1,99 +1,94 @@
 <clr-wizard #wizard [(clrWizardOpen)]="opened" clrWizardSize="lg">
-    <clr-wizard-title>Upload Plugin</clr-wizard-title>
-
-    <clr-wizard-button [type]="'cancel'">Cancel</clr-wizard-button>
-    <clr-wizard-button [type]="'previous'">Back</clr-wizard-button>
-    <clr-wizard-button [type]="'next'">Next</clr-wizard-button>
-    <clr-wizard-button [type]="'finish'">Finish</clr-wizard-button>
-
-    <clr-wizard-page [clrWizardPageNextDisabled]="!pluginBundle || !validPluginBundle">
-        <ng-template clrPageTitle>Select Plugin</ng-template>
-        <div *ngIf="loading" class="spinner spinner-sm"></div>
-        <clr-alert *ngIf="activityError" clrAlertType="danger">
-            <div class="alert-item">
-                <span class="alert-text">
-                    {{activityError}}
-                </span>
+        <clr-wizard-title>Upload Plugin</clr-wizard-title>
+    
+        <clr-wizard-button [type]="'cancel'">Cancel</clr-wizard-button>
+        <clr-wizard-button [type]="'previous'">Back</clr-wizard-button>
+        <clr-wizard-button [type]="'next'">Next</clr-wizard-button>
+        <clr-wizard-button [type]="'finish'">Finish</clr-wizard-button>
+    
+        <clr-wizard-page [clrWizardPageNextDisabled]="!pluginBundle">
+            <ng-template clrPageTitle>Select Plugin</ng-template>
+            <div *ngIf="loading" class="spinner spinner-sm"></div>
+            <clr-alert *ngIf="activityError" clrAlertType="danger">
+                <div class="alert-item">
+                    <span class="alert-text">
+                        {{activityError}}
+                    </span>
+                </div>
+            </clr-alert>
+            <button id="button" class="btn btn-link" (click)="onSelectPluginClick()">Select Plugin File</button>
+            <section *ngIf="pluginBundle">
+                <dl>
+                    <dt>Name</dt>
+                    <dd>{{pluginBundle.manifest.name}}</dd>
+    
+                    <dt>Vendor</dt>
+                    <dd>{{pluginBundle.manifest.vendor}}</dd>
+    
+                    <dt>Description</dt>
+                    <dd>{{pluginBundle.manifest.description}}</dd>
+    
+                    <dt>Version</dt>
+                    <dd>{{pluginBundle.manifest.version}}</dd>
+    
+                    <dt>License</dt>
+                    <dd>{{pluginBundle.manifest.license}}</dd>
+    
+                    <dt>Link</dt>
+                    <dd>{{pluginBundle.manifest.link}}</dd>
+                </dl>
+            </section>
+        </clr-wizard-page>
+    
+        <clr-wizard-page (clrWizardPageNext)="onPublishFormFinished()">
+            <ng-template clrPageTitle>Select Scope &amp; Publishing</ng-template>
+            <vcd-ext-publish-form #publishForm>
+            </vcd-ext-publish-form>
+        </clr-wizard-page>
+    
+        <clr-wizard-page clrWizardPagePreventDefaultNext="true"
+                         [clrWizardPageNextDisabled]="uploading"
+                         (clrWizardPageFinish)="onWizardFinished()">
+            <ng-template clrPageTitle>Review &amp; Finish</ng-template>
+            <clr-alert *ngIf="activityError" clrAlertType="danger">
+                <div class="alert-item">
+                    <span class="alert-text">
+                        {{activityError}}
+                    </span>
+                </div>
+            </clr-alert>
+            <progress *ngIf="uploading" max="100" [value]="(uploadingProgress|async)?.percent">
+            </progress>
+            <div *ngIf="uploading" class="spinner spinner-sm">
             </div>
-        </clr-alert>
-        <button id="button" class="btn btn-link" (click)="onSelectPluginClick()">Select Plugin File</button>
-        <section *ngIf="pluginBundle">
-            <dl>
-                <dt>Validated?</dt>
-                <dd>
-                    <clr-icon *ngIf="validPluginBundle" shape="check"></clr-icon>
-                    <clr-icon *ngIf="!validPluginBundle" shape="times"></clr-icon>
-                </dd>
-
-                <dt>Name</dt>
-                <dd>{{pluginBundle.manifest.name}}</dd>
-
-                <dt>Vendor</dt>
-                <dd>{{pluginBundle.manifest.vendor}}</dd>
-
-                <dt>Description</dt>
-                <dd>{{pluginBundle.manifest.description}}</dd>
-
-                <dt>Version</dt>
-                <dd>{{pluginBundle.manifest.version}}</dd>
-
-                <dt>License</dt>
-                <dd>{{pluginBundle.manifest.license}}</dd>
-
-                <dt>Link</dt>
-                <dd>{{pluginBundle.manifest.link}}</dd>
-            </dl>
-        </section>
-    </clr-wizard-page>
-
-    <clr-wizard-page (clrWizardPageNext)="onPublishFormFinished()">
-        <ng-template clrPageTitle>Select Scope &amp; Publishing</ng-template>
-        <vcd-ext-publish-form #publishForm>
-        </vcd-ext-publish-form>
-    </clr-wizard-page>
-
-    <clr-wizard-page clrWizardPagePreventDefaultNext="true"
-                     [clrWizardPageNextDisabled]="uploading"
-                     (clrWizardPageFinish)="onWizardFinished()">
-        <ng-template clrPageTitle>Review &amp; Finish</ng-template>
-        <clr-alert *ngIf="activityError" clrAlertType="danger">
-            <div class="alert-item">
-                <span class="alert-text">
-                    {{activityError}}
-                </span>
-            </div>
-        </clr-alert>
-        <progress *ngIf="uploading" max="100" [value]="(uploadingProgress|async)?.percent">
-        </progress>
-        <div *ngIf="uploading" class="spinner spinner-sm">
-        </div>
-        <section *ngIf="pluginBundle && publishOperation">
-            <dl>
-                <dt>Plugin</dt>
-                <dd>{{pluginBundle.manifest.name}}</dd>
-
-                <dt>Version</dt>
-                <dd>{{pluginBundle.manifest.version}}</dd>
-
-                <dt>Provider Scoping</dt>
-                <dd>
-                    <clr-icon *ngIf="publishOperation.providerScoped" shape="check"></clr-icon>
-                    <clr-icon *ngIf="!publishOperation.providerScoped" shape="times"></clr-icon>
-                </dd>
-
-                <dt>Tenant Scoping</dt>
-                <dd>
-                    <clr-icon *ngIf="publishOperation.tenantScoped" shape="check"></clr-icon>
-                    <clr-icon *ngIf="!publishOperation.tenantScoped" shape="times"></clr-icon>
-                </dd>
-
-                <ng-container *ngIf="publishOperation.tenantScoped">
-                    <dt>Tenant Publishing</dt>
+            <section *ngIf="pluginBundle && publishOperation">
+                <dl>
+                    <dt>Plugin</dt>
+                    <dd>{{pluginBundle.manifest.name}}</dd>
+    
+                    <dt>Version</dt>
+                    <dd>{{pluginBundle.manifest.version}}</dd>
+    
+                    <dt>Provider Scoping</dt>
                     <dd>
-                        Publish to {{publishOperation.tenants.length}} tenant(s)
+                        <clr-icon *ngIf="publishOperation.providerScoped" shape="check"></clr-icon>
+                        <clr-icon *ngIf="!publishOperation.providerScoped" shape="times"></clr-icon>
                     </dd>
-                </ng-container>
-            </dl>
-        </section>
-    </clr-wizard-page>
-</clr-wizard>
+    
+                    <dt>Tenant Scoping</dt>
+                    <dd>
+                        <clr-icon *ngIf="publishOperation.tenantScoped" shape="check"></clr-icon>
+                        <clr-icon *ngIf="!publishOperation.tenantScoped" shape="times"></clr-icon>
+                    </dd>
+    
+                    <ng-container *ngIf="publishOperation.tenantScoped">
+                        <dt>Tenant Publishing</dt>
+                        <dd>
+                            Publish to {{publishOperation.tenants.length}} tenant(s)
+                        </dd>
+                    </ng-container>
+                </dl>
+            </section>
+        </clr-wizard-page>
+    </clr-wizard>
+    

--- a/src/main/plugins/upload-wizard.component.ts
+++ b/src/main/plugins/upload-wizard.component.ts
@@ -24,7 +24,6 @@ export class UploadWizardComponent {
     uploaded = new EventEmitter<PluginUploadOperationSpec>();
 
     opened = false;
-    validPluginBundle = false;
     pluginBundle: PluginBundleSpec = null;
     publishOperation: PublishPluginsOperationSpec = null;
 
@@ -50,7 +49,6 @@ export class UploadWizardComponent {
     open() {
         this.wizard.reset();
         this.uploadingProgress = null;
-        this.validPluginBundle = false;
         this.activityError = null;
         this.pluginBundle = null;
         this.publishOperation = null;
@@ -69,7 +67,6 @@ export class UploadWizardComponent {
                 const providerScoped = result.manifest.scope.indexOf("service-provider") !== -1;
                 this.publishForm.reset([], {tenantScoped, providerScoped});
                 this.pluginBundle = result;
-                this.validPluginBundle = this.pluginBundleService.validatePluginBundle(result);
                 this.activitySubscription = null;
             }, (error) => {
                 console.error(error);


### PR DESCRIPTION
Remove  the plugin file validation, because with the  incremental
loading in place the plugins will have the ability to upload any kind
of files. Also the server doens't have  validation on its side, which means
in case there are any security vulnerabilities the UI is not capable to
stop them.

Update @vcd/sdk to v0.12.0

Testing Done:
- Verfiy the plugin works e2e