### PR TITLE
[VACE-2730] [Scale]Extension publish action can't publish

### DIFF
--- a/src/main/plugins/publish-form.component.ts
+++ b/src/main/plugins/publish-form.component.ts
@@ -53,6 +53,10 @@ export class PublishFormComponent {
             const oldValue = {...formGroup.value};
             formGroup.setValue({...oldValue, selected, indeterminate: false});
         }
+
+        if (selected && !this.form.dirty) {
+            this.form.markAsDirty();
+        }
     }
 
     isFilterMatching(tenantId: string) {


### PR DESCRIPTION
Mark the form as dirty after select all tenants
while publish in order to enable the save button.

Testing done:
- Verify the publish works
- Verify the plugin is compiled

Signed-off-by: Nikola Vladimirov Iliev <nvladimirovi@vmware.com>