### PR TITLE
[VACE-2774] [TestFest] Customize Portal is not publishing the plugin to all tenants, if all is selected

### DIFF
--- a/src/main/plugins/plugin-operations.model.ts
+++ b/src/main/plugins/plugin-operations.model.ts
@@ -16,4 +16,5 @@ export interface PluginUploadOperationSpec {
     plugin: PluginSpec;
     pluginBundle: PluginBundleSpec;
     tenants: PluginTenantSpec[];
+    publishToAll: boolean;
 }

--- a/src/main/plugins/plugin-operations.service.ts
+++ b/src/main/plugins/plugin-operations.service.ts
@@ -39,7 +39,7 @@ export class PluginOperationsService {
         return Observable.of(uploadState)
             .pipe(
                 flatMap((state) => this.createPlugin(state)),
-		flatMap((state) => this.publishToTenants(state)),
+                flatMap((state) => this.publishToTenants(state)),
                 flatMap((state) => this.transferPluginBundle(state, progressListener))
             );
     }
@@ -62,11 +62,12 @@ export class PluginOperationsService {
     }
 
     private publishToTenants(state: PluginUploadOperationSpec) {
-        return this.pluginService
-            .publishToTenants(state.plugin, state.tenants)
-            .pipe(
-                map((tenants) => ({...state, tenants}))
-            );
+        return (state.publishToAll ?
+            this.pluginService.publishToAllTenants(state.plugin) :
+            this.pluginService.publishToTenants(state.plugin, state.tenants)
+        ).pipe(
+            map((tenants) => ({...state, tenants}))
+        );
     }
 
     publishPlugins(publishState: PublishPluginsOperationSpec): Observable<PublishPluginsOperationSpec> {

--- a/src/main/plugins/upload-wizard.component.ts
+++ b/src/main/plugins/upload-wizard.component.ts
@@ -109,7 +109,8 @@ export class UploadWizardComponent {
         const upload: PluginUploadOperationSpec = {
             plugin,
             pluginBundle: this.pluginBundle,
-            tenants: this.publishOperation.tenants
+            tenants: this.publishOperation.tenants,
+            publishToAll: this.publishOperation.publishToAll
         };
         this.uploadingProgress = new Subject<TransferProgress>();
         this.activitySubscription = this.pluginOperationsService


### PR DESCRIPTION
[VACE-2774] [TestFest] Customize Portal is not publishing the plugin to all tenants, if all is selected

Publish the plugin to all tenants using publishAll endpoint
when uploading a plugin if all is selected.

Depends on: https://github.com/vmware-samples/vcd-ext-samples/pull/27

Testing Done:
- Verify when uploading plugin to specifc tenants
publish endpoint is used and publishAll if all is selected.

Signed-off-by: Nikola Vladimirov Iliev <nvladimirovi@vmware.com>