### PR TITLE
Add the new extension points to the showcase plugin (VM/vApp Modal/Wizard Extensibility)

### DIFF
--- a/src/main/create-vapp/index.ts
+++ b/src/main/create-vapp/index.ts
@@ -1,0 +1,2 @@
+export { VappCreateWizardExtensionPointComponent } from "./vapp.create.wizard.action.component";
+

--- a/src/main/create-vapp/vapp.create.wizard.action.component.html
+++ b/src/main/create-vapp/vapp.create.wizard.action.component.html
@@ -1,0 +1,4 @@
+<clr-input-container>
+    <label>Create vApp Extensibility</label>
+    <input clrInput type="text" />
+</clr-input-container>

--- a/src/main/create-vapp/vapp.create.wizard.action.component.ts
+++ b/src/main/create-vapp/vapp.create.wizard.action.component.ts
@@ -1,0 +1,12 @@
+import { Component } from "@angular/core";
+import { WizardExtensionComponent } from "@vcd/sdk/common";
+
+@Component({
+    selector: 'vapp-create-extension',
+    templateUrl: './vapp.create.wizard.action.component.html'
+})
+export class VappCreateWizardExtensionPointComponent extends WizardExtensionComponent<any, any, any> {
+    performAction(payoad: string, returnValue: string, error: any) {
+        console.log("[vApp Create Wizard Extension Point]", payoad, returnValue, error);
+    }
+}

--- a/src/main/create-vm/index.ts
+++ b/src/main/create-vm/index.ts
@@ -1,0 +1,2 @@
+export { VmCreateWizardExtensionPointComponent } from "./vm.create.wizard.action.component";
+

--- a/src/main/create-vm/vm.create.wizard.action.component.html
+++ b/src/main/create-vm/vm.create.wizard.action.component.html
@@ -1,0 +1,4 @@
+<clr-input-container>
+    <label>Create VM Extensibility</label>
+    <input clrInput type="text" />
+</clr-input-container>

--- a/src/main/create-vm/vm.create.wizard.action.component.ts
+++ b/src/main/create-vm/vm.create.wizard.action.component.ts
@@ -1,0 +1,12 @@
+import { Component } from "@angular/core";
+import { WizardExtensionComponent } from "@vcd/sdk/common";
+
+@Component({
+    selector: 'vm-create-extension',
+    templateUrl: './vm.create.wizard.action.component.html'
+})
+export class VmCreateWizardExtensionPointComponent extends WizardExtensionComponent<any, any, any> {
+    performAction(payoad: string, returnValue: string, error: any) {
+        console.log("[VM Create Wizard Extension Point]", payoad, returnValue, error);
+    }
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -5,3 +5,5 @@ export { ApplicationComponent } from './application/application.component';
 export { DatacenterComputeComponent } from './datacenter-compute/datacenter-compute.component';
 export { DatacenterNetworkComponent } from './datacenter-network/datacenter-network.component';
 export { DatacenterStorageComponent } from './datacenter-storage/datacenter-storage.component';
+export { VmCreateWizardExtensionPointComponent } from './create-vm';
+export { VappCreateWizardExtensionPointComponent } from './create-vapp';

--- a/src/main/subnav-plugin.module.ts
+++ b/src/main/subnav-plugin.module.ts
@@ -17,8 +17,10 @@ import {
     ApplicationComponent,
     DatacenterComputeComponent,
     DatacenterNetworkComponent,
-    DatacenterStorageComponent
+    DatacenterStorageComponent,
+    VmCreateWizardExtensionPointComponent
 } from ".";
+import { VappCreateWizardExtensionPointComponent } from "./create-vapp";
 
 const ROUTES: Routes = [
     { path: "", component: SubnavComponent, children: [
@@ -46,6 +48,8 @@ const ROUTES: Routes = [
         DatacenterComputeComponent,
         DatacenterNetworkComponent,
         DatacenterStorageComponent,
+        VappCreateWizardExtensionPointComponent,
+        VmCreateWizardExtensionPointComponent,
     ],
     entryComponents: [
         DatacenterContainerComponent,
@@ -55,6 +59,8 @@ const ROUTES: Routes = [
         DatacenterComputeComponent,
         DatacenterNetworkComponent,
         DatacenterStorageComponent,
+        VappCreateWizardExtensionPointComponent,
+        VmCreateWizardExtensionPointComponent,
     ],
     bootstrap: [SubnavComponent],
     exports: [],

--- a/src/public/manifest.json
+++ b/src/public/manifest.json
@@ -71,5 +71,49 @@
         "name": "Datacetner Storage Extenson Point (New)",
         "description": "Display custom information in the Datacetner -> Storage section",
         "component": "DatacenterStorageComponent"
+    },
+    {
+        "urn": "vmware:vcloud:vapp:create",
+        "type": "create-vapp",
+        "name": "vApp Create Extension Point",
+        "description": "Example of vApp Create Extensibility",
+        "component": "VappCreateWizardExtensionPointComponent",
+        "run": "after", 
+        "render": {
+            "after": ".power-on"
+        }
+    },
+    {
+        "urn": "vmware:vcloud:vapp:create:ovf",
+        "type": "create-vapp-ovf",
+        "name": "vApp Create Extension Point",
+        "description": "Example of vApp Create From OVF Extensibility",
+        "component": "VappCreateWizardExtensionPointComponent",
+        "run": "after",
+        "render": {
+            "after": ".upload-ovf"
+        }
+    },
+    {
+        "urn": "vmware:vcloud:vapp:create:template",
+        "type": "create-vapp-template",
+        "name": "vApp Create Extension Point",
+        "description": "Example of vApp Create From Tempalte Extensibility",
+        "component": "VappCreateWizardExtensionPointComponent",
+        "run": "after",
+        "render": {
+            "after": ".select-name-and-leases"
+        }
+    },
+    {
+        "urn": "vmware:vcloud:vm:create",
+        "type": "create-vm",
+        "name": "VM Create Extension Point",
+        "description": "Example of VM Create Extensibility",
+        "component": "VmCreateWizardExtensionPointComponent",
+        "run": "after",
+        "render": {
+            "after": ".vm-description"
+        }
     }]
 }


### PR DESCRIPTION
Add the new extension points to the showcase plugin (VM/vApp Modal/Wizard Extensibility)

Add 4 new extension  points related with modal/wizard
extensibility.

**Note:** We've to release new version of the @vcd/sdk package to support the new interface contract for
wizard/modal extensibility.

Tracked by: VACE-2821

Testing Done:
- Verify the plugin is compiled and works
- Verify the payload response and or error are
all sent to the extension  point when the certain
event occur (for example create vm).

![image](https://user-images.githubusercontent.com/29869465/101645420-079ccf80-3a3f-11eb-82b5-807ea583e9b9.png)
![image](https://user-images.githubusercontent.com/29869465/101645468-16838200-3a3f-11eb-8356-d0c099b0d045.png)
![image](https://user-images.githubusercontent.com/29869465/101645515-23a07100-3a3f-11eb-8910-3a74cf0fb9f5.png)
![image](https://user-images.githubusercontent.com/29869465/101645565-32872380-3a3f-11eb-87a2-89906099975a.png)
