### PR TITLE
[VM/vApp Extensibility] Create UI Utility which will persist data aft…

### DIFF
--- a/src/main/create-vapp/index.ts
+++ b/src/main/create-vapp/index.ts
@@ -1,2 +1,1 @@
 export { VappCreateWizardExtensionPointComponent } from "./vapp.create.wizard.action.component";
-

--- a/src/main/create-vapp/vapp.create.wizard.action.component.ts
+++ b/src/main/create-vapp/vapp.create.wizard.action.component.ts
@@ -1,12 +1,24 @@
-import { Component } from "@angular/core";
+import { Component, OnDestroy } from "@angular/core";
 import { WizardExtensionComponent } from "@vcd/sdk/common";
+import { ModalWizardExtensionPointService } from "../services/modal-wizard-ext-point.service";
 
 @Component({
     selector: 'vapp-create-extension',
     templateUrl: './vapp.create.wizard.action.component.html'
 })
-export class VappCreateWizardExtensionPointComponent extends WizardExtensionComponent<any, any, any> {
-    performAction(payoad: string, returnValue: string, error: any) {
-        console.log("[vApp Create Wizard Extension Point]", payoad, returnValue, error);
+export class VappCreateWizardExtensionPointComponent extends WizardExtensionComponent<any, any, any> implements OnDestroy {
+    constructor(private modalWizardExtensionPointService: ModalWizardExtensionPointService) {
+        super();
+
+        this.modalWizardExtensionPointService.inVappContext();
+    }
+    
+    performAction(payload: string, returnValue: string, error: any) {
+        console.log("[vApp Create Wizard Extension Point]", payload, returnValue, error);
+        this.modalWizardExtensionPointService.storeData<string[]>([payload, returnValue]);
+    }
+
+    ngOnDestroy() {
+        this.modalWizardExtensionPointService.exitVappContext();
     }
 }

--- a/src/main/create-vm/vm.create.wizard.action.component.html
+++ b/src/main/create-vm/vm.create.wizard.action.component.html
@@ -1,4 +1,6 @@
-<clr-input-container>
+<clr-input-container *ngIf="!inVappContext">
     <label>Create VM Extensibility</label>
     <input clrInput type="text" />
 </clr-input-container>
+
+<p *ngIf="inVappContext">In vApp Context</p>

--- a/src/main/create-vm/vm.create.wizard.action.component.ts
+++ b/src/main/create-vm/vm.create.wizard.action.component.ts
@@ -1,12 +1,28 @@
-import { Component } from "@angular/core";
+import { Component, OnDestroy } from "@angular/core";
 import { WizardExtensionComponent } from "@vcd/sdk/common";
+import { ModalWizardExtensionPointService } from "../services/modal-wizard-ext-point.service";
 
 @Component({
     selector: 'vm-create-extension',
     templateUrl: './vm.create.wizard.action.component.html'
 })
-export class VmCreateWizardExtensionPointComponent extends WizardExtensionComponent<any, any, any> {
-    performAction(payoad: string, returnValue: string, error: any) {
-        console.log("[VM Create Wizard Extension Point]", payoad, returnValue, error);
+export class VmCreateWizardExtensionPointComponent extends WizardExtensionComponent<any, any, any> implements OnDestroy {
+    inVappContext = false;
+
+    constructor(private modalWizardExtensionPointService: ModalWizardExtensionPointService) {
+        super();
+        
+        this.modalWizardExtensionPointService.inVappContextObs.subscribe((value) => {
+            this.inVappContext = value;
+        });
+    }
+
+    ngOnDestroy() {
+        console.log("[VmCreateWizardExtensionPointComponent] Destroyed!");
+    }
+
+    performAction(payload: string, returnValue: string, error: any) {
+        console.log("[VM Create Wizard Extension Point]", payload, returnValue, error);
+        this.modalWizardExtensionPointService.storeData<string[]>([payload, returnValue]);
     }
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -6,4 +6,6 @@ export { DatacenterComputeComponent } from './datacenter-compute/datacenter-comp
 export { DatacenterNetworkComponent } from './datacenter-network/datacenter-network.component';
 export { DatacenterStorageComponent } from './datacenter-storage/datacenter-storage.component';
 export { VmCreateWizardExtensionPointComponent } from './create-vm';
-export { VappCreateWizardExtensionPointComponent } from './create-vapp';
+export {
+    VappCreateWizardExtensionPointComponent,
+} from './create-vapp';

--- a/src/main/services/modal-wizard-ext-point.service.ts
+++ b/src/main/services/modal-wizard-ext-point.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from "@angular/core";
+import { BehaviorSubject } from "rxjs";
+
+@Injectable()
+export class ModalWizardExtensionPointService {
+    inVappContextSubject = new BehaviorSubject<boolean>(false);
+    inVappContextObs = this.inVappContextSubject.asObservable();
+
+    constructor() {
+        console.log("[ModalWizardExtensionPointService] Init!");
+    }
+
+    public inVappContext() {
+        console.log("[ModalWizardExtensionPointService] Enter vApp Context!");
+        this.inVappContextSubject.next(true);
+    }
+
+    public exitVappContext() {
+        console.log("[ModalWizardExtensionPointService] Exit vApp Context!");
+
+        this.inVappContextSubject.next(false);
+    }
+
+    public storeData<T>(data: T) {
+        // Store your data
+        console.log("Data stored!");
+    }
+}

--- a/src/main/subnav-plugin.module.ts
+++ b/src/main/subnav-plugin.module.ts
@@ -21,6 +21,7 @@ import {
     VmCreateWizardExtensionPointComponent
 } from ".";
 import { VappCreateWizardExtensionPointComponent } from "./create-vapp";
+import { ModalWizardExtensionPointService } from "./services/modal-wizard-ext-point.service";
 
 const ROUTES: Routes = [
     { path: "", component: SubnavComponent, children: [
@@ -64,7 +65,7 @@ const ROUTES: Routes = [
     ],
     bootstrap: [SubnavComponent],
     exports: [],
-    providers: [VcdApiClient]
+    providers: [VcdApiClient, ModalWizardExtensionPointService]
 })
 export class SubnavPluginModule extends PluginModule {
     constructor(appStore: Store<any>, @Inject(EXTENSION_ROUTE) extensionRoute: string, translate: TranslateService) {

--- a/src/public/manifest.json
+++ b/src/public/manifest.json
@@ -80,29 +80,7 @@
         "component": "VappCreateWizardExtensionPointComponent",
         "run": "after", 
         "render": {
-            "after": ".power-on"
-        }
-    },
-    {
-        "urn": "vmware:vcloud:vapp:create:ovf",
-        "type": "create-vapp-ovf",
-        "name": "vApp Create Extension Point",
-        "description": "Example of vApp Create From OVF Extensibility",
-        "component": "VappCreateWizardExtensionPointComponent",
-        "run": "after",
-        "render": {
-            "after": ".upload-ovf"
-        }
-    },
-    {
-        "urn": "vmware:vcloud:vapp:create:template",
-        "type": "create-vapp-template",
-        "name": "vApp Create Extension Point",
-        "description": "Example of vApp Create From Tempalte Extensibility",
-        "component": "VappCreateWizardExtensionPointComponent",
-        "run": "after",
-        "render": {
-            "after": ".select-name-and-leases"
+            "after": ".vapp-name-extension-point"
         }
     },
     {


### PR DESCRIPTION
…er component destruction

Refactor the manifest json file to support one vapp
extension point but shown in different vapp screens (new/ovf/template).

Create utility service which will be used as an example of
that how to persist your data after vm/vapp creation.

Tracked by: VACE-3119

Testing Done:
- Verify the plugin is compiled and works
- Verify the payload response and or error are
all sent to the extension  point when the certain
event occur (for example create vm).
- Verify one vapp extension point definision
is shown in all the create vapp screens