### PR TITLE
Theme Generator VCD 10.2.2 - missing logout options

### DIFF
--- a/src/.vcd/common/_common.scss
+++ b/src/.vcd/common/_common.scss
@@ -268,6 +268,11 @@ vcd-advanced-sort {
         transform: translateX(15rem);
         overflow-x: hidden;
         overflow-y: auto;
+
+        .nav-list {
+            display: block;
+        }
+        
         .nav-group {
             color: $clr-sidenav-header-color;
             font-size: 0.583333rem;


### PR DESCRIPTION
Issue
On mobile resolutions the user preferences dropdown menu
is broken. This is caused by missing styles in the theme
generator vcd base styles file.
https://github.com/vmware-samples/vcd-ext-samples/issues/73

Fix
Add the styles for proper mobile visualization.

![image](https://user-images.githubusercontent.com/29869465/145410537-946fb9c0-788f-4fe5-ba99-f61e4b317d80.png)

Signed-off-by: Nikola Vladimirov Iliev <nvladimirovi@vmware.com>