### PR TITLE
[SDK] When fail to load plugin using @vcd/ui-components

### DIFF
--- a/ticketing/packages/uiPlugin/angular.json
+++ b/ticketing/packages/uiPlugin/angular.json
@@ -13,6 +13,22 @@
           "builder": "@vcd/plugin-builders:plugin-builder",
           "options": {
             "modulePath": "src/main/ticketing.module.ts#TicketingPluginModule",
+            "ignoreDefaultExternals": true,
+            "externalLibs": [
+              "@angular/common$",
+              "@angular/common/http$",
+              "@angular/core$",
+              "@angular/forms$",
+              "@angular/platform-browser$",
+              "@angular/router$",
+              "@clr/angular$",
+              "@ngrx/store$",
+              "^@vcd\/common$",
+              "^@vcd-ui\/common$",
+              "rxjs$",
+              "rxjs/internal-compatibility$",
+              "rxjs/operators$"
+            ],
             "outputPath": "dist/",
             "index": "src/index.html",
             "main": "src/plugin.main.ts",


### PR DESCRIPTION
Issue
The existing reg exprestion in our plugin builder is
targeting all angular depencies when we talk making
them "external", in webpack context. This works fine
as long as the plugin depends on angular depencies
that are provided by the Core UI.
However is some cases some other missing angular libs might be used by the plugin, for example @angular/testing.

Fix
Specify list of dependencies in ticketing project,
so @angular/testing won't be a provided by the Core UI.
Note this dependency won't be executed in any way in
runtime.

Testing Done:
Build ticketing example and deploy it to vcd
Verify the plugin is loaded
Verify the plugin works