### PR TITLE
Fix theme generator for vCD 10.2 and 10.3.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The theme generator contains a sample base theme, which is Clarity's unmodified 
 ```bash
 npm run build -- --theme=base --optimize
 ```
+> Note: For release 10.2 and 10.3 replace the usage of `clr-default-borderwidth` with `clr-table-borderwidth` in `src/.vcd/vcd.scss`
 
 This will produce a `base.css` file in the `target/` folder.  Any number of themes can be managed as directories under the `src/` folder.  A folder with valid Sass content can be used as the `--theme` parameter value in the above build command.
 

--- a/src/.vcd/vcd.scss
+++ b/src/.vcd/vcd.scss
@@ -179,6 +179,8 @@ $horizontalPadding: ($clr-datagrid-fixed-column-size - 1.25rem) / 2;
 
 .table {
     .table-expandable-caret {
+        // Uncomment if you want to build theme for VMware Cloud Director 10.2 or 10.3
+        // padding: calc(0.125rem - #{$clr-table-borderwidth}) $horizontalPadding 0.125rem;
         padding: calc(0.125rem - #{$clr-default-borderwidth}) $horizontalPadding 0.125rem;
         text-align: center;
 


### PR DESCRIPTION
The SCSS var clr-default-borderwidth is not present in those
two release, actually it's replaced with clr-table-borderwidth.

The fix is just to replace clr-default-borderwidth with
clr-table-borderwidth

Addreses issue https://github.com/vmware-samples/vcd-ext-samples/issues/82

Signed-off-by: Nikola Vladimirov Iliev <nvladimirovi@vmware.com>